### PR TITLE
Palette closed when color chosen... closes #45, closes #56

### DIFF
--- a/build/src/lib/annotate/index.js
+++ b/build/src/lib/annotate/index.js
@@ -213,6 +213,9 @@ module.exports = function (background) {
                     localStorage.setItem('palette-color', config.baseColor);
                 }
                 clearPaletteSelected();
+                annotate.palette.style.display = 'none';
+                mouse.listen();
+                _setEditBehavior();
                 this.className += " palette-selected";
             }
         }
@@ -225,6 +228,7 @@ module.exports = function (background) {
         // This runs on right click
         window.addEventListener('contextmenu', function(ev) {
             ev.preventDefault();
+            annotate.tooltip.style.display = 'none';
             annotate.palette.style.display = 'block';
             annotate.palette.style.left = ev.pageX + "px";
             annotate.palette.style.top = ev.pageY + "px";
@@ -247,6 +251,8 @@ module.exports = function (background) {
         // LABS-622
         annotate.paletteClose.onclick = function() {
             annotate.palette.style.display = 'none';
+            mouse.listen();
+            _setEditBehavior();
         }
 
         annotate.openModal.onclick = function() {


### PR DESCRIPTION
1. Palette closed when color chosen,
2. Tooltip does not cover palette, 
3. Focus is back that were lost when aforementioned issues implemented.